### PR TITLE
fix build error

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -21,12 +21,7 @@ import { Helmet } from "react-helmet";
 import { format } from "date-fns";
 import NotFound from "../pages/NotFound/NotFound";
 
-import {
-  useLocation,
-  useParams,
-  useSearchParams,
-  Navigate,
-} from "react-router-dom";
+import { useLocation, useParams, useSearchParams } from "react-router-dom";
 
 const baseurl = process.env.PUBLIC_URL || "";
 


### PR DESCRIPTION
The build was failing because `Navigate` was defined but never used, as seen in [this action](https://github.com/wrynearson/willwill.run/actions/runs/11105990983/job/30854061080#step:11:24). Warnings were treated as errors in the GitHub action: 

> Treating warnings as errors because process.env.CI = true.